### PR TITLE
cmake: don't use EXCLUDE_FROM_ALL with interface libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ set(SRCS
 # COMMON LIBRARY
 # ------------------------------------------------------------------------------
 
-add_library(tig_common INTERFACE EXCLUDE_FROM_ALL)
+add_library(tig_common INTERFACE)
 
 target_include_directories(tig_common INTERFACE
     ${FPATTERN_INCLUDE_DIR}


### PR DESCRIPTION
Using EXCLUDE_FROM_ALL with interface libraries requires CMake 3.19 or newer, but let's keep the minimum required version to 3.13, which is the last version that runs on Windows 5.x (XP, Server 2003).