### PR TITLE
use a less obscure name for 64-bit types

### DIFF
--- a/include/tig/str_parse.h
+++ b/include/tig/str_parse.h
@@ -12,14 +12,14 @@ void tig_str_parse_exit();
 void tig_str_parse_set_separator(int sep);
 void tig_str_parse_str_value(char** str, char* value);
 void tig_str_parse_value(char** str, int* value);
-void tig_str_parse_value_64(char** str, long long* value);
+void tig_str_parse_value_64(char** str, int64_t* value);
 void tig_str_parse_range(char** str, int* start, int* end);
 void tig_str_parse_complex_value(char** str, int delim, int* value1, int* value2);
 void tig_str_parse_complex_value3(char** str, int delim, int* value1, int* value2, int* value3);
 void tig_str_parse_complex_str_value(char** str, int delim, const char** list, int list_length, int* value1, int* value2);
 void tig_str_match_str_to_list(char** str, const char** list, int list_length, int* value);
 void tig_str_parse_flag_list(char** str, const char** keys, const unsigned int* values, int length, unsigned int* value);
-void tig_str_parse_flag_list_64(char** str, const char** keys, const unsigned long long* values, int length, unsigned long long* value);
+void tig_str_parse_flag_list_64(char** str, const char** keys, const uint64_t* values, int length, uint64_t* value);
 bool tig_str_parse_named_value(char** str, const char* name, int* value);
 bool tig_str_parse_named_str_value(char** str, const char* name, char* value);
 bool tig_str_match_named_str_to_list(char** str, const char* name, const char** list, int list_length, int* value);
@@ -28,7 +28,7 @@ bool tig_str_parse_named_flag_list(char** str, const char* name, const char** ke
 bool tig_str_parse_named_complex_value(char** str, const char* name, int delim, int* value1, int* value2);
 bool tig_str_parse_named_complex_value3(char** str, const char* name, int delim, int* value1, int* value2, int* value3);
 bool tig_str_parse_named_complex_str_value(char** str, const char* name, int delim, const char** list, int list_length, int* value1, int* value2);
-bool tig_str_parse_named_flag_list_64(char** str, const char* name, const char** keys, unsigned long long* values, int length, unsigned long long* value);
+bool tig_str_parse_named_flag_list_64(char** str, const char* name, const char** keys, uint64_t* values, int length, uint64_t* value);
 bool tig_str_parse_named_flag_list_direct(char** str, const char* name, const char** keys, int length, unsigned int* value);
 void tig_str_parse_flag_list_direct(char** str, const char** keys, int length, unsigned int* value);
 

--- a/src/str_parse.c
+++ b/src/str_parse.c
@@ -77,7 +77,7 @@ void tig_str_parse_value(char** str, int* value)
 }
 
 // 0x531A20
-void tig_str_parse_value_64(char** str, long long* value)
+void tig_str_parse_value_64(char** str, int64_t* value)
 {
     while (isspace(*(*str))) {
         (*str)++;
@@ -394,7 +394,7 @@ void tig_str_parse_flag_list(char** str, const char** keys, const unsigned int* 
 }
 
 // 0x531FB0
-void tig_str_parse_flag_list_64(char** str, const char** keys, const unsigned long long* values, int length, unsigned long long* value)
+void tig_str_parse_flag_list_64(char** str, const char** keys, const uint64_t* values, int length, uint64_t* value)
 {
     *value = 0;
 
@@ -698,7 +698,7 @@ bool tig_str_parse_named_complex_str_value(char** str, const char* name, int del
 }
 
 // 0x5329E0
-bool tig_str_parse_named_flag_list_64(char** str, const char* name, const char** keys, unsigned long long* values, int length, unsigned long long* value)
+bool tig_str_parse_named_flag_list_64(char** str, const char* name, const char** keys, uint64_t* values, int length, uint64_t* value)
 {
     *value = 0;
 


### PR DESCRIPTION
replace 'long long' with 'int64_t'
replace 'unsigned long long' with 'uint64_t'