### PR TITLE
replace 'LSTATUS' with 'LONG'

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -186,7 +186,7 @@ void tig_debug_init_backends()
 void tig_debug_init_backends_from_registry()
 {
 #ifdef _WIN32
-    LSTATUS rc;
+    LONG rc;
     HKEY key;
     DWORD type;
     DWORD data;


### PR DESCRIPTION
When Arcanum was being developed, the Windows SDK declared 'RegOpenKeyExA' as returning a 'LONG'. The 'LSTATUS' type came much later, with the SDK for Windows Vista in 2006.