### PR TITLE
replace #include <timeapi.h> with <mmsystem.h>

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -13,7 +13,7 @@
 
 // clang-format off
 #include <windows.h>
-#include <timeapi.h>
+#include <mmsystem.h>
 // clang-format on
 
 #define RESOLUTION 1


### PR DESCRIPTION
When Arcanum was being developed, "timeapi.h" didn't exist. Its functionality at that time was in "mmsystem.h". The "timeapi.h" header came much later, with the SDK for Windows 7 in 2009.